### PR TITLE
Fix unit summaries for listings directory

### DIFF
--- a/apps/public/pages/listings.tsx
+++ b/apps/public/pages/listings.tsx
@@ -6,7 +6,7 @@ import ListingsList, {
   ListingsProps
 } from "@bloom/ui-components/src/page_components/listing/ListingsList"
 import axios from "axios"
-import { unitSummariesTable } from "../lib/unit_summaries"
+import { unitSummariesTable } from "../lib/tableSummaries"
 
 export default class extends Component<ListingsProps> {
   public static async getInitialProps() {


### PR DESCRIPTION
Unit summaries got changed after I worked on then and path have been changed. This one updates the path.