### PR TITLE
Fix the package name and add deployment docs

### DIFF
--- a/apps/public/pages/HousingCounselors.tsx
+++ b/apps/public/pages/HousingCounselors.tsx
@@ -1,10 +1,10 @@
 import { Component } from "react"
 import axios from "axios"
 
-import { HousingCounselor as Counselor } from "@bloom/core/src/HousingCounselors"
-import HousingCounselor from "@bloom/ui-components/src/page_components/HousingCounselor"
-import PageHeader from "@bloom/ui-components/src/headers/page_header/page_header"
-import t from "@bloom/ui-components/src/helpers/translator"
+import { HousingCounselor as Counselor } from "@bloom-housing/core/src/HousingCounselors"
+import HousingCounselor from "@bloom-housing/ui-components/src/page_components/HousingCounselor"
+import PageHeader from "@bloom-housing/ui-components/src/headers/page_header/page_header"
+import t from "@bloom-housing/ui-components/src/helpers/translator"
 
 import Layout from "../layouts/application"
 

--- a/docs/DeployAppsNetlify.md
+++ b/docs/DeployAppsNetlify.md
@@ -1,0 +1,18 @@
+# Deplying Bloom Apps to Netlify
+
+The Bloom front-end applications are designed to be stateless, and thus can be deployed as static sites to Netlify or directly to any major hosting environment (e.g. AWS, GCP, Azure). The following information is intended to help guide the deployment of the reference implementation to Netlify, but can also serve as a starting point for other front-end deployment scenarios
+
+## Per-app Deployment
+
+Because Bloom uses a monorepo style of organization, there are likely multiple apps (e.g. public and partners) that will each need their own deployment configuration. Each build configuation should make sure to work from the correct code base directory, for example the public app build command might be:
+
+    cd apps/public; yarn run build ; yarn run export
+
+## Server-side Rendering
+
+## Environment Variables
+
+In addition to those environment variables defined in .env.template for the relevant applications, make sure to define the following variables to ensure the release process is consistent with the Bloom supported versions:
+
+- NODE_VERSION
+- YARN_VERSION

--- a/docs/DeployServicesHeroku.md
+++ b/docs/DeployServicesHeroku.md
@@ -1,0 +1,11 @@
+# Deploying Bloom Services to Heroku
+
+Bloom is designed to use a set of independently run services that provide the data and business logic processing needed by the front-end apps. While the Bloom architecture accomodates services built and operated in a variety of environments, the reference implementation includes services that can be easily run within the [Heroku PaaS environment](https://www.heroku.com/).
+
+## Monorepo Buildpack
+
+Since the Bloom repository uses a monorepo layout, all Heroku services must use the [monorepo buildpack](https://elements.heroku.com/buildpacks/lstoll/heroku-buildpack-monorepo).
+
+## Procfile
+
+## Environment Variables

--- a/shared/ui-components/src/page_components/HousingCounselor.tsx
+++ b/shared/ui-components/src/page_components/HousingCounselor.tsx
@@ -1,8 +1,8 @@
 import * as React from "react"
 
-import { HousingCounselor as Counselor } from "@bloom/core/src/HousingCounselors"
+import { HousingCounselor as Counselor } from "@bloom-housing/core/src/HousingCounselors"
 
-import t from "@bloom/ui-components/src/helpers/translator"
+import t from "@bloom-housing/ui-components/src/helpers/translator"
 
 const LanguageLabel = (language: string) => {
   return (


### PR DESCRIPTION
Some old ```@bloom``` package naming snuck in with #84, so correcting that and throwing in some rough deployment documentation that I was working on (@jaredcwhite and @software-project, feel free to add to those whenever you come across new things).